### PR TITLE
Basic WASM Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ parallel = ['rayon']
 [dependencies]
 num-traits = "0.2.12"
 byteorder = "1.3.4"
+wasm-bindgen = "0.2.63"
+console_error_panic_hook = "0.1.6"
 
 rayon = { version = "1.2.0", optional = true }
 
@@ -30,3 +32,9 @@ harness = false
 
 [package.metadata.docs.rs]
 features = ["parallel"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies.js-sys]
+version = "0.3.4"

--- a/examples/wasm.html
+++ b/examples/wasm.html
@@ -20,7 +20,6 @@
         };
 
         const file = "../tests/data/point-color.laz";
-        // const lazrs = import("../pkg/laz.js");
         import init, { get_header, init_decompressor, decompress_many } from "../pkg/laz.js";
 
         init()
@@ -41,45 +40,12 @@
                                 for (var i = 0; i < 10; i++) {
                                     decompress_many(vlr, out);
                                     console.log(out)
-                                var dv = new DataView(out.buffer);
+                                    var dv = new DataView(out.buffer);
                                     console.log(pointFormatReaders[uncompressed_pointformat](dv));
                                 }
-                                // decompress_many(vlr, out);
-                                // console.log(out);
-                                // decompress_many(vlr, out);
-                                // console.log(out);
-                                // decompress_many(vlr, out);
-                                // console.log(out);
-                                // decompress_many(vlr, out);
-                                // console.log(out);
                             });
                     });
             });
-
-
-        // lazrs
-        //     .then((laz) => {
-        //         fetch(file)
-        //             .then(response => {
-        //                 response.arrayBuffer()
-        //                     .then((buf) => {
-        //                         var header = laz.get_header(buf);
-        //                     });
-        //             });
-        //         // let reader = new FileReader();
-
-        //         // reader.readAsArrayBuffer(file);
-
-        //         // reader.onload = function() {
-        //         // console.log(reader.result);
-        //         // };
-
-        //         // reader.onerror = function() {
-        //         // console.log(reader.error);
-        //         // };
-        //         //   laz.greet("WebAssembly")
-        //     })
-        //     .catch(console.error);
     </script>
 </body>
 

--- a/examples/wasm.html
+++ b/examples/wasm.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <title>hello-wasm example</title>
+</head>
+
+<body>
+    <script type="module">
+        var pointFormatReaders = {
+            0: function(dv) {
+                return {
+                    "position": [ dv.getInt32(0, true), dv.getInt32(4, true), dv.getInt32(8, true)],
+                    "intensity": dv.getUint16(12, true),
+                    "classification": dv.getUint8(16, true)
+                };
+            },
+            1: function(dv) {
+                return {
+                    "position": [ dv.getInt32(0, true), dv.getInt32(4, true), dv.getInt32(8, true)],
+                    "intensity": dv.getUint16(12, true),
+                    "classification": dv.getUint8(16, true)
+                };
+            },
+            2: function(dv) {
+                return {
+                    "position": [ dv.getInt32(0, true), dv.getInt32(4, true), dv.getInt32(8, true)],
+                    "intensity": dv.getUint16(12, true),
+                    "classification": dv.getUint8(15, true),
+                    "color": [dv.getUint16(20, true), dv.getUint16(22, true), dv.getUint16(24, true)]
+                };
+            },
+            3: function(dv) {
+                return {
+                    "position": [ dv.getInt32(0, true), dv.getInt32(4, true), dv.getInt32(8, true)],
+                    "intensity": dv.getUint16(12, true),
+                    "classification": dv.getUint8(16, true),
+                    "color": [dv.getUint16(28, true), dv.getUint16(30, true), dv.getUint16(32, true)]
+                };
+            },
+            7: function(dv) {
+                return {
+                    "position": [ dv.getInt32(0, true), dv.getInt32(4, true), dv.getInt32(8, true)],
+                    "intensity": dv.getUint16(12, true),
+                    "classification": dv.getUint8(16, true),
+                    "color": [dv.getUint16(28, true), dv.getUint16(30, true), dv.getUint16(32, true)]
+                };
+            }
+        };
+
+        const file = "../tests/data/point-color.laz";
+        // const lazrs = import("../pkg/laz.js");
+        import init, { get_header, init_decompressor, decompress_many } from "../pkg/laz.js";
+
+        init()
+            .then(() => {
+                fetch(file)
+                    .then(response => {
+                        response.arrayBuffer()
+                            .then((buf) => {
+                                var abInt = new Uint8Array(buf);
+                                var header = get_header(abInt);
+                                console.log(header);
+                                var vlr = init_decompressor(abInt, header);
+                                console.log(vlr);
+
+                                var uncompressed_pointformat = header.point_format_id & 0x3f;
+
+                                var out = new Uint8Array(header.point_size);
+                                for (var i = 0; i < 10; i++) {
+                                    decompress_many(vlr, out);
+                                    console.log(out)
+                                var dv = new DataView(out.buffer);
+                                    console.log(pointFormatReaders[uncompressed_pointformat](dv));
+                                }
+                                // decompress_many(vlr, out);
+                                // console.log(out);
+                                // decompress_many(vlr, out);
+                                // console.log(out);
+                                // decompress_many(vlr, out);
+                                // console.log(out);
+                                // decompress_many(vlr, out);
+                                // console.log(out);
+                            });
+                    });
+            });
+
+
+        // lazrs
+        //     .then((laz) => {
+        //         fetch(file)
+        //             .then(response => {
+        //                 response.arrayBuffer()
+        //                     .then((buf) => {
+        //                         var header = laz.get_header(buf);
+        //                     });
+        //             });
+        //         // let reader = new FileReader();
+
+        //         // reader.readAsArrayBuffer(file);
+
+        //         // reader.onload = function() {
+        //         // console.log(reader.result);
+        //         // };
+
+        //         // reader.onerror = function() {
+        //         // console.log(reader.error);
+        //         // };
+        //         //   laz.greet("WebAssembly")
+        //     })
+        //     .catch(console.error);
+    </script>
+</body>
+
+</html>

--- a/examples/wasm.html
+++ b/examples/wasm.html
@@ -9,42 +9,12 @@
 <body>
     <script type="module">
         var pointFormatReaders = {
-            0: function(dv) {
-                return {
-                    "position": [ dv.getInt32(0, true), dv.getInt32(4, true), dv.getInt32(8, true)],
-                    "intensity": dv.getUint16(12, true),
-                    "classification": dv.getUint8(16, true)
-                };
-            },
-            1: function(dv) {
-                return {
-                    "position": [ dv.getInt32(0, true), dv.getInt32(4, true), dv.getInt32(8, true)],
-                    "intensity": dv.getUint16(12, true),
-                    "classification": dv.getUint8(16, true)
-                };
-            },
             2: function(dv) {
                 return {
                     "position": [ dv.getInt32(0, true), dv.getInt32(4, true), dv.getInt32(8, true)],
                     "intensity": dv.getUint16(12, true),
                     "classification": dv.getUint8(15, true),
                     "color": [dv.getUint16(20, true), dv.getUint16(22, true), dv.getUint16(24, true)]
-                };
-            },
-            3: function(dv) {
-                return {
-                    "position": [ dv.getInt32(0, true), dv.getInt32(4, true), dv.getInt32(8, true)],
-                    "intensity": dv.getUint16(12, true),
-                    "classification": dv.getUint8(16, true),
-                    "color": [dv.getUint16(28, true), dv.getUint16(30, true), dv.getUint16(32, true)]
-                };
-            },
-            7: function(dv) {
-                return {
-                    "position": [ dv.getInt32(0, true), dv.getInt32(4, true), dv.getInt32(8, true)],
-                    "intensity": dv.getUint16(12, true),
-                    "classification": dv.getUint8(16, true),
-                    "color": [dv.getUint16(28, true), dv.getUint16(30, true), dv.getUint16(32, true)]
                 };
             }
         };

--- a/src/las/file.rs
+++ b/src/las/file.rs
@@ -6,9 +6,11 @@
 use crate::las::laszip::{LasZipDecompressor, LazVlr};
 use byteorder::{LittleEndian, ReadBytesExt};
 use std::io::{Read, Seek, SeekFrom};
+use wasm_bindgen::prelude::*;
 
 /// LAS header with only the minimum information
 /// to be able to read points contained in a LAS file.
+#[wasm_bindgen]
 #[derive(Debug)]
 pub struct QuickHeader {
     pub major: u8,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,68 +140,42 @@ pub use las::laszip::{
     par_compress_buffer, par_decompress_buffer, ParLasZipCompressor, ParLasZipDecompressor,
 };
 
-// pub use las::laszip::{
-//     read_chunk_table, write_chunk_table, LasZipCompressor, LasZipDecompressor, LazItem,
-//     LazItemRecordBuilder, LazItemType, LazVlr, LazVlrBuilder,
-// };
+pub use las::laszip::{
+    read_chunk_table, write_chunk_table, LasZipCompressor, LasZipDecompressor, LazItem,
+    LazItemRecordBuilder, LazItemType, LazVlr, LazVlrBuilder,
+};
 
 pub type Result<T> = std::result::Result<T, LasZipError>;
 
 use las::file::read_vlrs_and_get_laszip_vlr;
 use las::file::QuickHeader;
 use wasm_bindgen::prelude::*;
+use std::io::Seek;
 extern crate console_error_panic_hook;
-
-// #[wasm_bindgen]
-// pub struct WasmVlrHeader {
-//     pub header: QuickHeader,
-//     pub vlr: Option<LazVlr>
-// }
 
 #[wasm_bindgen]
 pub fn get_header(buf: js_sys::Uint8Array)  -> std::result::Result<QuickHeader, JsValue> {
+    // initialize debugging
     console_error_panic_hook::set_once();
+
+    // copy header bytes into wasm memory
     let mut body = vec![0; buf.length() as usize];
     buf.copy_to(&mut body[..]);
+    // cursor to wrap the bytes
     let mut cursor = std::io::Cursor::new(body);
     let hdr = QuickHeader::read_from(&mut cursor).unwrap();
-    // let (header, vlr) = (read_header_and_vlrs(&mut cursor)).unwrap();
-    // let out = WasmVlrHeader {header, vlr};
     Ok(hdr)
 }
-use std::io::Seek;
-
-// #[wasm_bindgen]
-// pub struct WasmDecompressor {
-//     decompressor: las::file::SimpleReader<'static>
-// }
-
-// #[wasm_bindgen]
-// impl WasmDecompressor {
-//     pub fn new(buf: &[u8]) -> WasmDecompressor {
-//         let mut cursor = std::io::Cursor::new(buf);
-//         let mut decompressor = las::file::SimpleReader::new(&mut cursor).unwrap();
-//         WasmDecompressor { decompressor: decompressor }
-//     }
-
-//     // pub fn get(&self) -> i32 {
-//     //     self.decompressor
-//     // }
-
-//     // pub fn set(&mut self, val: i32) {
-//     //     self.decompressor = val;
-//     // }
-// }
 
 #[wasm_bindgen]
-pub struct LasZipDecompressor2 {
+pub struct WasmLasZipDecompressor {
     decompressor: las::laszip::LasZipDecompressor<'static, std::io::Cursor<Vec<u8>>>,
 }
 
-impl LasZipDecompressor2 {
+impl WasmLasZipDecompressor {
     pub fn new(source: Vec<u8>) -> Self {        
         let mut cursor = std::io::Cursor::new(source);
-        //let cursor = source;
+
         let hdr = QuickHeader::read_from(&mut cursor).unwrap();
         cursor.seek(std::io::SeekFrom::Start(hdr.header_size as u64));
         let laz_vlr = read_vlrs_and_get_laszip_vlr(&mut cursor, &hdr);
@@ -211,53 +185,19 @@ impl LasZipDecompressor2 {
         Self {
             decompressor: decomp,
         }
-        // let mut decompressor = LasZipDecompressor::new(&mut cursor, laz_vlr.expect("Compressed data, but no Laszip Vlr found")).unpack();
-    
-        // let gil = Python::acquire_gil();
-        // let py = gil.python();
-        // let vlr = laz::LazVlr::from_buffer(as_bytes(record_data)?).map_err(into_py_err)?;
-        // let source = BufReader::new(PyReadableFileObject::new(py, source)?);
-        // Ok(Self {
-        //     decompressor: laz::LasZipDecompressor::new(source, vlr).map_err(into_py_err)?,
-        // })
     }
 
     pub fn decompress_many(&mut self, out: &mut [u8]) -> std::io::Result<()> {
-        // let slc = as_mut_bytes(dest)?;
         Ok(self.decompressor.decompress_many(out)?)
-        //Ok(());
     }
-
-    // pub fn seek(&mut self, point_idx: u64) -> PyResult<()> {
-    //     self.decompressor.seek(point_idx).map_err(into_py_err)
-    // }
-
-    // pub fn vlr(&self) -> LazVlr {
-    //     return LazVlr {
-    //         vlr: self.decompressor.vlr().clone(),
-    //     };
-    // }
 }
 
 #[wasm_bindgen]
-pub fn init_decompressor(buf: js_sys::Uint8Array)  -> LasZipDecompressor2  {
-    // let mut cursor = std::io::Cursor::new(buf);
-    // let mut reader = las::file::SimpleReader::new(&mut cursor).unwrap();
-    // Ok(WasmDecompressor { decompressor: reader })
-    // let mut cursor = std::io::Cursor::new(buf);
-    // cursor.seek(std::io::SeekFrom::Start(hdr.header_size as u64));
-    // let laz_vlr = read_vlrs_and_get_laszip_vlr(&mut cursor, &hdr);
-    // cursor.seek(std::io::SeekFrom::Start(hdr.offset_to_points as u64));
-    // let mut body = vec![0; buf.length() as usize];
-    // buf.copy_to(&mut body[..]);
-    let mut decompressor = LasZipDecompressor2::new(buf.to_vec());
-    decompressor
-    // WasmDecompressor{decompressor}
+pub fn init_decompressor(buf: js_sys::Uint8Array)  -> WasmLasZipDecompressor  {
+    WasmLasZipDecompressor::new(buf.to_vec())
 }
 
 #[wasm_bindgen]
-pub fn decompress_many(decompressor: &mut LasZipDecompressor2, out: &mut [u8]) {
-    // let slc = as_mut_bytes(dest)?;
+pub fn decompress_many(decompressor: &mut WasmLasZipDecompressor, out: &mut [u8]) {
     decompressor.decompressor.decompress_many(out);
-    //Ok(());
 }


### PR DESCRIPTION
Hi,

I've been working on getting laz-rs compiled for WASM. Here's a very crude implementation which only supports Decompression at the moment. However, it's fully functional, and supports reading `n` points at a time via `decompress_many`.

To test it, you can use:

```
wasm-pack build --target web --debug
python3 -m http.server --bind 127.0.0.1
```

Then navigate to `http://127.0.0.1:8000/examples/wasm.html`. 

I'm not very familiar with Rust, so please feel free to edit or give me suggestions how to improve, especially with the `Result` stuff.