### PR TITLE
Update LazVlrBuilder to create defaults from laz_items

### DIFF
--- a/src/las/laszip/vlr.rs
+++ b/src/las/laszip/vlr.rs
@@ -455,13 +455,14 @@ impl LazVlrBuilder {
         }
     }
 
-    pub fn with_chunk_size(mut self, chunk_size: u32) -> Self {
-        self.laz_vlr.chunk_size = chunk_size;
-        self
+    pub fn from_laz_items(laz_items: Vec<LazItem>) -> Self {
+        Self {
+            laz_vlr: LazVlr::from_laz_items(laz_items),
+        }
     }
 
-    pub fn with_laz_items(mut self, laz_items: Vec<LazItem>) -> Self {
-        self.laz_vlr.items = laz_items;
+    pub fn with_chunk_size(mut self, chunk_size: u32) -> Self {
+        self.laz_vlr.chunk_size = chunk_size;
         self
     }
 


### PR DESCRIPTION
Previously, when using `with_laz_items`, the created VLR would not set the appropriate defaults based on the laz items. Now, the user can create a VLR with defaults for a point type, and customize the chunk size.