### PR TITLE
Deprecation message fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ rayon = { version = "1.2.0", optional = true }
 criterion = "0.2"
 glob = "0.3.0"
 indicatif = "0.16.2"
-clap = "3.0.0-beta.2"
+clap = "3.0.0-beta.5"
 
 [[bench]]
 name = "benchmark"

--- a/examples/check.rs
+++ b/examples/check.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 
-use clap::Clap;
+use clap::Parser;
 use glob::GlobError;
 use indicatif::{ProgressBar, ProgressStyle};
 
@@ -90,7 +90,7 @@ type DefaultCompressorCreator = SimpleCompressorCreator;
 #[cfg(not(feature = "parallel"))]
 type DefaultDecompressorCreator = SimpleDecompressorCreator;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 struct Arguments {
     path: String,
     num_points_per_iter: Option<i64>,

--- a/src/laszip/mod.rs
+++ b/src/laszip/mod.rs
@@ -23,7 +23,7 @@ mod vlr;
 pub const LASZIP_USER_ID: &str = LazVlr::USER_ID;
 #[deprecated(since = "0.6.0", note = "Please use laz::LazVlr::RECORD_ID")]
 pub const LASZIP_RECORD_ID: u16 = LazVlr::RECORD_ID;
-#[deprecated(since = "0.6.0", note = "Please use laz::LazVlr::USER_ID")]
+#[deprecated(since = "0.6.0", note = "Please use laz::LazVlr::DESCRIPTION")]
 pub const LASZIP_DESCRIPTION: &str = LazVlr::DESCRIPTION;
 
 pub trait LazDecompressor {


### PR DESCRIPTION
There was a copypasta in one deprecation message. Also includes a clap version bump (required because 3.0.0-beta.5 was getting pulled in even with the beta.2 specification).