### PR TITLE
Fix LasZipCompressor with empty input data

### DIFF
--- a/src/laszip/compression.rs
+++ b/src/laszip/compression.rs
@@ -127,6 +127,9 @@ impl<'a, W: Write + Seek + Send + 'a> LasZipCompressor<'a, W> {
 
     /// Must be called when you have compressed all your points.
     pub fn done(&mut self) -> std::io::Result<()> {
+        if self.chunk_start_pos == 0 {
+            self.reserve_offset_to_chunk_table()?;
+        }
         self.record_compressor.done()?;
         self.update_chunk_table()?;
         let stream = self.record_compressor.get_mut();

--- a/src/laszip/mod.rs
+++ b/src/laszip/mod.rs
@@ -40,7 +40,7 @@ pub trait LazCompressor {
 
 #[cfg(test)]
 mod test {
-    use std::io::Cursor;
+    use std::io::{Cursor, Seek, SeekFrom};
 
     use super::*;
 
@@ -53,6 +53,21 @@ mod test {
                 .len(),
             1
         );
+    }
+
+    #[test]
+    fn test_compress_empty_buffer() {
+        let vlr = super::LazVlr::from_laz_items(
+            LazItemRecordBuilder::new()
+                .add_item(LazItemType::Point10)
+                .build(),
+        );
+        let header = vec![42; 10];
+        let mut write = Cursor::new(header.clone());
+        write.seek(SeekFrom::Start(header.len() as u64)).unwrap();
+        compress_buffer(&mut write, &[], vlr).unwrap();
+        let data = write.into_inner();
+        assert!(data.starts_with(&header));
     }
 
     macro_rules! test_manual_reserve_on {


### PR DESCRIPTION
I ran into an edge case with the `laz::laszip::compression::LasZipCompressor` while trying to write *.laz files. When trying to write a *.laz file with 0 points, it produces incorrect results.

The problem is, that with empty input data, `compress_one` will never be called. Since this seems to be the only place, where `self.start_pos` is initialized, it will still be `0`, when `done` is called, resulting in it seeking to the wrong position when updating the chunk table offset.

In my case, that lead to the beginning of the las header being overwritten, giving me corrupted *.laz files.

This PR contains a (trivial) fix for this edge case and also adds a test for it.