### PR TITLE
Add get() and into_inner() on appenders

### DIFF
--- a/src/laszip/parallel/appender.rs
+++ b/src/laszip/parallel/appender.rs
@@ -60,6 +60,14 @@ where
     pub fn get_mut(&mut self) -> &mut W {
         self.compressor.get_mut()
     }
+
+    pub fn get(&self) -> &W {
+        self.compressor.get()
+    }
+
+    pub fn into_inner(self) -> W {
+        self.compressor.into_inner()
+    }
 }
 
 impl<W> ParLasZipAppender<W>

--- a/src/laszip/sequential/appender.rs
+++ b/src/laszip/sequential/appender.rs
@@ -130,6 +130,14 @@ where
     pub fn get_mut(&mut self) -> &mut W {
         self.compressor.get_mut()
     }
+
+    pub fn get(&self) -> &W {
+        self.compressor.get()
+    }
+
+    pub fn into_inner(self) -> W {
+        self.compressor.into_inner()
+    }
 }
 
 impl<'a, W> LasZipAppender<'a, W>


### PR DESCRIPTION
This adds `fn get()` and `fn into_inner()` on LasZipAppender and ParLasZipAppender