### PR TITLE
Correctly use has_changed tracking

### DIFF
--- a/src/las/nir.rs
+++ b/src/las/nir.rs
@@ -264,10 +264,14 @@ pub mod v3 {
         }
 
         fn write_layers_sizes(&mut self, dst: &mut R) -> std::io::Result<()> {
-            if self.has_nir_changed {
+            let num_bytes = if self.has_nir_changed {
                 self.encoder.done()?;
-            }
-            dst.write_u32::<LittleEndian>(self.encoder.get_mut().get_ref().len() as u32)?;
+                self.encoder.get_mut().get_ref().len() as u32
+            } else {
+                0
+            };
+            dst.write_u32::<LittleEndian>(num_bytes)?;
+
             Ok(())
         }
 

--- a/src/las/rgb.rs
+++ b/src/las/rgb.rs
@@ -860,10 +860,14 @@ pub mod v3 {
         }
 
         fn write_layers_sizes(&mut self, dst: &mut R) -> std::io::Result<()> {
-            if self.rgb_has_changed {
+            let num_bytes = if self.rgb_has_changed {
                 self.encoder.done()?;
-            }
-            dst.write_u32::<LittleEndian>(inner_buffer_len_of(&self.encoder) as u32)?;
+                inner_buffer_len_of(&self.encoder) as u32
+            } else {
+                0
+            };
+            dst.write_u32::<LittleEndian>(num_bytes)?;
+
             Ok(())
         }
 

--- a/src/las/wavepacket.rs
+++ b/src/las/wavepacket.rs
@@ -618,10 +618,13 @@ pub mod v3 {
         }
 
         fn write_layers_sizes(&mut self, dst: &mut W) -> std::io::Result<()> {
-            if self.has_changed {
+            let num_bytes = if self.has_changed {
                 self.encoder.done()?;
-            }
-            dst.write_u32::<LittleEndian>(inner_buffer_len_of(&self.encoder) as u32)?;
+                inner_buffer_len_of(&self.encoder) as u32
+            } else {
+                0
+            };
+            dst.write_u32::<LittleEndian>(num_bytes)?;
             Ok(())
         }
 


### PR DESCRIPTION
Layered compressors tracks if data actually changed as even if the data did not change, compressors will output some bytes

We were not correctly using that information when writing layer sizes and layer bytes, leading to us writing more bytes than laszip would.

This however did not harm in any way as it could only happen on layer which did not change, and as we wrote a size which was correct with how many bytes we wrote other impl (and us) would not trip on it.

This change is 'cosmetic', just to have this impl write the exact same number of bytes than laszip.