### PR TITLE
ParLasZipDecompressor: use read_exact not read

### DIFF
--- a/src/laszip/parallel/decompression.rs
+++ b/src/laszip/parallel/decompression.rs
@@ -140,7 +140,7 @@ impl<R: Read + Seek> ParLasZipDecompressor<R> {
 
         // Read the necessary compressed bytes into our internal buffer
         self.internal_buffer.resize(num_bytes_to_read, 0u8);
-        self.source.read(&mut self.internal_buffer)?;
+        self.source.read_exact(&mut self.internal_buffer)?;
 
         // 3. Decompress
         // The idea is that if we have `n` chunks to decompress


### PR DESCRIPTION
We were using `read` instead of `read_exact` when reading from the source to fill our internal buffer.

However read does not guarantee that it will fill the output buffer, and intead returns how many bytes it read.

Our intent was to use read_exact, which is now the case.

The bug when triggered, meant that the internal buffer was incomplete leading to decompressor decompressing wrong data and creating EOF errors.

Luckily to trigger the bug some the source must be in non-standard conditions. For example, as often the source is a BufReader, but with a buffer capacity
>= chunk size, which is not the defaul setting. This would lead to
the BufReader empyting its buffer, but not making sur our buffer was filled.

Fixes #59 