### PR TITLE
Fix ParLazDecompressor seek when file use variable chunk size

### DIFF
--- a/src/laszip/mod.rs
+++ b/src/laszip/mod.rs
@@ -12,6 +12,9 @@ pub use vlr::{
     LazVlrBuilder, Version1, Version2, Version3,
 };
 
+#[cfg(feature = "parallel")]
+pub(crate) use vlr::DecompressedChunkSize;
+
 mod chunk_table;
 mod details;
 #[cfg(feature = "parallel")]


### PR DESCRIPTION
When we seek to a point, the ParLazDecompressor decompresses the whole chunk it belongs to, and so we resize an internal buffer so that it has enough free bytes.

We call `num_bytes_in_decompressed_chunk` to computes the number of bytes to allocate.

However, the way the  computation was done was only valid when the file uses non variable chunk size, as the `chunk_size` variable (which stores the number of points in a chunk) is only valid of fixed size chunk, as other wise it contains a sentinel value, that is u64::MAX, leading to trying a big allocation when the file uses variable chunk size, like COPC files.

The fix is to make `num_bytes_in_decompressed_chunk` return an enum to let the caller handle the differences between Fixed/Variable as the vlr does not have the necessary stuff to handle the Variable case, where the caller has (or should).

Fixes https://github.com/gadomski/las-rs/issues/125