### PR TITLE
Interpret 0 as variable chunk size

### DIFF
--- a/src/laszip/parallel/decompression.rs
+++ b/src/laszip/parallel/decompression.rs
@@ -244,7 +244,11 @@ impl<R: Read + Seek> ParLasZipDecompressor<R> {
             let num_bytes_decompressed =
                 decompressor.decompress_until_end_of_file(self.rest.get_mut())?;
             let num_points_in_last_chunk = num_bytes_decompressed / self.vlr.items_size() as usize;
-            let pos_in_chunk = index % self.vlr.chunk_size() as u64;
+            let pos_in_chunk = if self.vlr.uses_variable_size_chunks() {
+                index
+            } else {
+                index % self.vlr.chunk_size() as u64
+            };
             if pos_in_chunk as usize >= num_points_in_last_chunk as usize {
                 // Make the rest appear as fully consumed to
                 // force EOF error on next decompression
@@ -256,7 +260,11 @@ impl<R: Read + Seek> ParLasZipDecompressor<R> {
         }
         // This effectively discard points that were
         // before the one we just seeked to
-        let pos_in_chunk = index % self.vlr.chunk_size() as u64;
+        let pos_in_chunk = if self.vlr.uses_variable_size_chunks() {
+            index as u64
+        } else {
+            index % self.vlr.chunk_size() as u64
+        };
         self.rest.set_position(pos_in_chunk * self.vlr.items_size());
         self.last_chunk_read = chunk_of_point as isize;
         Ok(())

--- a/src/laszip/sequential/compression.rs
+++ b/src/laszip/sequential/compression.rs
@@ -96,7 +96,7 @@ impl<'a, W: Write + Seek + Send + Sync + 'a> LasZipCompressor<'a, W> {
         }
 
         // Since in variable-size chunks mode the vlr.chunk_size() is
-        // u32::max this should not interfere.
+        // u32::max or 0 this should not interfere.
         if self.current_chunk_entry.point_count == self.vlr.chunk_size() as u64 {
             self.finish_current_chunk_impl()?;
         }

--- a/src/laszip/vlr.rs
+++ b/src/laszip/vlr.rs
@@ -477,7 +477,7 @@ impl LazVlr {
     #[inline]
     /// Returns whether the chunk size is variable.
     pub fn uses_variable_size_chunks(&self) -> bool {
-        self.chunk_size == Self::VARIABLE_CHUNK_SIZE
+        self.chunk_size == Self::VARIABLE_CHUNK_SIZE || self.chunk_size == 0
     }
 
     /// Returns the chunk size, that is, the number of points in each chunk.


### PR DESCRIPTION
In the LAZ Specification under 7.1 Chunk Size it says that adaptive chunking is used if the chunk size value is 2<sup>32</sup> *or 0*.

This change adds support for the 'or 0' part.