### PR TITLE
Fix panic in parallel decompressor when chunk table is empty

### DIFF
--- a/src/laszip/parallel/decompression.rs
+++ b/src/laszip/parallel/decompression.rs
@@ -133,6 +133,13 @@ impl<R: Read + Seek> ParLasZipDecompressor<R> {
         }
         let end_index = start_index + num_chunks_to_decompress;
 
+        if num_chunks_to_decompress == 0 {
+            return Err(LasZipError::IoError(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "no chunks available in chunk table",
+            )));
+        }
+
         debug_assert!(num_chunks_to_decompress >= 1);
         debug_assert!(num_points >= num_requested_points_left);
         // TODO if num_points >= num_requested_points_left then the user ask to decompress more points


### PR DESCRIPTION
When a LAZ file has an empty chunk table, `decompress_many` reaches` end_index - 1` with` end_index == 0`. In release mode the subtraction wraps to `usize::MAX` and the subsequent slice index panics:

```
range end index 18446744073709551615 out of range for slice of length 0
at src/laszip/parallel/decompression.rs:152

```
The existing `debug_assert!(num_chunks_to_decompress >= 1)` catches this in debug builds but not in release. This PR adds an explicit early return with `IoError(UnexpectedEof)` so callers can handle the condition gracefully instead of unwinding.

Encountered on a real-world LAZ file produced by a mobile scanner.